### PR TITLE
Update README with token rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ You can create a **Github personal access token** here:
 `https://github.com/settings/tokens`
 
 The token needs the following rights set:
-*  "read:org"
+*  "repo"
 *  "user:email"
-*  "repo_deployment"
-*  "repo:status"
 *  "write:repo_hook"
+*  "read:org"
 
 Make sure you save this token somewhere as github will only show it to you once.
 


### PR DESCRIPTION
The current token rights aren't sufficient to get a travis token for a private repo. I tested what is minimally needed and came to the conclusion that without repo it doesn't work. Github removes the  "repo_deployment" and "repo:status" rights then, I guess because they overlap. I got the wallboard fully working with the token.